### PR TITLE
Add separate install scripts for game launchers, codekit, and package setup

### DIFF
--- a/install_codekit.ps1
+++ b/install_codekit.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string]
+    $Path
+)
+
+function install_codekit {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        install-script winget-install -force
+    }
+
+    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+        irm get.scoop.sh -outfile 'install.1.ps1'
+        .\install.1.ps1 -RunAsAdmin
+    }
+
+    md $path\codekit
+    cd $path\codekit
+
+    winget install --id Git.Git -s winget
+    winget install --id Microsoft.VisualStudioCode -s winget
+    winget install JanDeDobbeleer.OhMyPosh -s winget
+    winget install --id Microsoft.PowerShell.Preview --source winget
+
+    scoop install node
+    scoop install python
+    scoop install go
+}
+
+install_codekit -path $path

--- a/install_game.ps1
+++ b/install_game.ps1
@@ -5,23 +5,5 @@ param (
     $Path
 )
 
-function install_game {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [string]
-        $path
-    )
-
-
-    md $path\game
-    start-job {curl "https://cdn.akamai.steamstatic.com/client/installer/SteamSetup.exe" --output $path\game\steam_installer.exe}
-    start-job {curl  "https://dldir1.qq.com/tgc/wegame/miniloader/WeGameMiniLoader.std.5.12.21.1022.exe" --output $path\game\wegame_install.exe}    
-    start-job { curl "https://github.com/Voxelum/x-minecraft-launcher/releases/download/v0.46.1/xmcl-0.46.1-win32-x64.zip" --output $path\game\xmcl_install.exe}
-    start-job {curl "https://gamedownloads.rockstargames.com/public/installer/Rockstar-Games-Launcher.exe?_gl=1*1uzr7ch*_ga*MjEwMTA5MDc2OC4xNzI1OTcwMjYx*_ga_PJQ2JYZDQC*MTcyNTk3MDI2MC4xLjAuMTcyNTk3MDI2NC4wLjAuMA.." --output $path\game\rockstargames_install.exe}
-    start-job {curl "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-15.17.1.msi?launcherfilename=EpicInstaller-15.17.1-924c3ca127ce42be9c3ae18789d2cd86.msi" --output $path\hame\epicgames_install.exe}
-    
-    
-    
-}
-install_game -path $path    
+. "$PSScriptRoot\install_game_launchers.ps1"
+install_game_launchers -path $path

--- a/install_game_launchers.ps1
+++ b/install_game_launchers.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string]
+    $Path
+)
+
+function install_game_launchers {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    md $path\game
+    start-job {curl "https://cdn.akamai.steamstatic.com/client/installer/SteamSetup.exe" --output $path\game\steam_installer.exe}
+    start-job {curl  "https://dldir1.qq.com/tgc/wegame/miniloader/WeGameMiniLoader.std.5.12.21.1022.exe" --output $path\game\wegame_install.exe}
+    start-job {curl "https://github.com/Voxelum/x-minecraft-launcher/releases/download/v0.46.1/xmcl-0.46.1-win32-x64.zip" --output $path\game\xmcl_install.exe}
+    start-job {curl "https://gamedownloads.rockstargames.com/public/installer/Rockstar-Games-Launcher.exe?_gl=1*1uzr7ch*_ga*MjEwMTA5MDc2OC4xNzI1OTcwMjYx*_ga_PJQ2JYZDQC*MTcyNTk3MDI2MC4xLjAuMTcyNTk3MDI2NC4wLjAuMA.." --output $path\game\rockstargames_install.exe}
+    start-job {curl "https://epicgames-download1.akamaized.net/Builds/UnrealEngineLauncher/Installers/Win32/EpicInstaller-15.17.1.msi?launcherfilename=EpicInstaller-15.17.1-924c3ca127ce42be9c3ae18789d2cd86.msi" --output $path\game\epicgames_install.exe}
+}
+
+install_game_launchers -path $path

--- a/install_package.ps1
+++ b/install_package.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [string]
+    $Path
+)
+
+function install_package {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        install-script winget-install -force
+    }
+
+    if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+        irm get.scoop.sh -outfile 'install.1.ps1'
+        .\install.1.ps1 -RunAsAdmin
+    }
+}
+
+install_package -path $path

--- a/install_software.ps1
+++ b/install_software.ps1
@@ -20,37 +20,12 @@ function install_software {
         instal_software
     }
 
- try {
-    wget 
- }
- catch {
-    get-wget
- }
-    
-    function get-wget {
-        #scooptintaller
-       
-       
-       irm get.scoop.sh -outfile 'install.1.ps1'
-       .\install.1.ps1 -RunAsAdmin 
-       # I don't care about other parameters and want a one-line command
-       iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-       
-       scoop install wget
-       }
-
     md $path\software
         cd $path\software 
-    #soundpad
-        git clone https://github.com/marhau-dev/Soundpad-cracked.git 
-        try {
-            wget
-        }
-        catch {
-            get_wget
-        }
-        #
     #winget
+    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+        install-script winget-install -force
+    }
     wget winget 
     #ohmyposh
     winget install JanDeDobbeleer.OhMyPosh -s winget


### PR DESCRIPTION
### Motivation
- Split a large, monolithic installer into smaller, focused scripts for maintainability and reuse.
- Separate flows are needed for game launchers, developer tooling (`codekit`), and package manager setup to reduce coupling.
- Ensure package managers are present before use so downstream installs are more robust by checking for `winget` and `scoop`.
- Remove brittle `wget` helper/retry logic and avoid cloning unwanted/cracked repositories.

### Description
- Added `install_game_launchers.ps1`, `install_codekit.ps1`, and `install_package.ps1` to encapsulate launcher, tooling, and package setup respectively.
- Modified `install_game.ps1` to source the new launcher script and call `install_game_launchers -path $path` as a thin wrapper.
- Cleaned up `install_software.ps1` by removing the `get-wget` retry block and the Soundpad clone, and added a `Get-Command winget` check with `install-script winget-install -force` when missing.
- New scripts install or ensure `scoop` via `irm get.scoop.sh` and use `winget`/`scoop` to install developer tools like `Git` and `Visual Studio Code` and runtimes such as `node`, `python`, and `go`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961eae4814c8331a45ae0646d7c83c8)